### PR TITLE
fix: loaclに指定するフォント名にファミリー名でなくフルネームを設定

### DIFF
--- a/assets/css/fonts.css
+++ b/assets/css/fonts.css
@@ -11,5 +11,5 @@
     font-family: Noto Sans JP;
     font-style: normal;
     font-weight: 700;
-    src: local("Noto Sans JP"),url(../fonts/NotoSansJP-Bold.woff2) format("woff2")
+    src: local("Noto Sans JP Bold"),url(../fonts/NotoSansJP-Bold.woff2) format("woff2")
 }


### PR DESCRIPTION
macosのchromeでは、localに指定するフォント名にフルネーム
"例: local('Noto Sans JP Bold')"を指定する必要があるようだ.(fix: #52)

デジタル庁のサイトでも同様に,local('Noto Sans JP')指定時は
macosのchromeでboldが表示されていない.